### PR TITLE
Fix/markdown link

### DIFF
--- a/src/components/InfoModal.tsx
+++ b/src/components/InfoModal.tsx
@@ -12,17 +12,16 @@ import ChipSkeleton from 'components/ChipSkeleton';
 import Comments from 'components/Comments';
 import EmployeeSelector from 'components/form/EmployeeSelector';
 import Modal from 'components/Modal';
-import TextMarkDownWithLink from 'components/TextMarkDownWithLink';
 import useSnackbar from 'context/Snackbar';
 import { useUser } from 'context/User';
 import { format } from 'date-fns';
 import { useRouter } from 'next/router';
 import { useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
+import ReactMarkdown from 'react-markdown';
 import useSWR from 'swr';
 import { IEmployeeTask } from 'utils/types';
 import { fetcher } from 'utils/utils';
-
 const useStyles = makeStyles((theme: Theme) => ({
   chip: {
     marginRight: theme.spacing(1),
@@ -199,7 +198,7 @@ const InfoModal = ({ employee_task_id, modalIsOpen, closeModal }: InfoModalProps
             <ChipSkeleton chipsAmount={5} />
           )}
         </Box>
-        <TextMarkDownWithLink text={data?.task.description} />
+        <ReactMarkdown>{data?.task.description}</ReactMarkdown>
         <Comments employeeTask={employee_task_id} />
       </>
     </Modal>

--- a/src/components/InfoModal.tsx
+++ b/src/components/InfoModal.tsx
@@ -44,6 +44,11 @@ const useStyles = makeStyles((theme: Theme) => ({
   skeletonHeight: {
     height: theme.spacing(24),
   },
+  link: {
+    '& a': {
+      color: theme.palette.text.primary,
+    },
+  },
 }));
 export const ResponsibleSelector = ({ employeeTask }: { employeeTask: IEmployeeTask }) => {
   const [hasSelectedNewResponsible, setHasSelectedNewResponsible] = useState<boolean>(false);
@@ -198,7 +203,7 @@ const InfoModal = ({ employee_task_id, modalIsOpen, closeModal }: InfoModalProps
             <ChipSkeleton chipsAmount={5} />
           )}
         </Box>
-        <ReactMarkdown>{data?.task.description}</ReactMarkdown>
+        <ReactMarkdown className={classes.link}>{data?.task.description}</ReactMarkdown>
         <Comments employeeTask={employee_task_id} />
       </>
     </Modal>

--- a/src/components/InfoModal.tsx
+++ b/src/components/InfoModal.tsx
@@ -11,6 +11,7 @@ import axios from 'axios';
 import ChipSkeleton from 'components/ChipSkeleton';
 import Comments from 'components/Comments';
 import EmployeeSelector from 'components/form/EmployeeSelector';
+import Markdown from 'components/Markdown';
 import Modal from 'components/Modal';
 import useSnackbar from 'context/Snackbar';
 import { useUser } from 'context/User';
@@ -18,7 +19,6 @@ import { format } from 'date-fns';
 import { useRouter } from 'next/router';
 import { useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import ReactMarkdown from 'react-markdown';
 import useSWR from 'swr';
 import { IEmployeeTask } from 'utils/types';
 import { fetcher } from 'utils/utils';
@@ -43,11 +43,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   skeletonHeight: {
     height: theme.spacing(24),
-  },
-  link: {
-    '& a': {
-      color: theme.palette.text.primary,
-    },
   },
 }));
 export const ResponsibleSelector = ({ employeeTask }: { employeeTask: IEmployeeTask }) => {
@@ -203,7 +198,7 @@ const InfoModal = ({ employee_task_id, modalIsOpen, closeModal }: InfoModalProps
             <ChipSkeleton chipsAmount={5} />
           )}
         </Box>
-        <ReactMarkdown className={classes.link}>{data?.task.description}</ReactMarkdown>
+        <Markdown text={data?.task.description} />
         <Comments employeeTask={employee_task_id} />
       </>
     </Modal>

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -1,0 +1,21 @@
+import { Theme } from '@mui/material/styles';
+import { makeStyles } from '@mui/styles';
+import ReactMarkdown from 'react-markdown';
+
+const useStyles = makeStyles((theme: Theme) => ({
+  link: {
+    '& a': {
+      color: theme.palette.text.primary,
+    },
+  },
+}));
+type MarkdownProps = {
+  text: string;
+};
+
+const Markdown = ({ text }: MarkdownProps) => {
+  const classes = useStyles();
+  return <ReactMarkdown className={classes.link}>{text}</ReactMarkdown>;
+};
+
+export default Markdown;

--- a/src/components/views/oppgaver/TaskRow.tsx
+++ b/src/components/views/oppgaver/TaskRow.tsx
@@ -67,8 +67,8 @@ const TaskRow = ({ data, displayResponsible }: { data: IEmployeeTask; displayRes
   const hasExpired = daysBeforeDueDate < 0;
 
   return (
-    <TableRow sx={{ border: 0, padding: '0' }}>
-      <TableCell sx={{ border: 0, padding: 0, whiteSpace: 'nowrap' }}>
+    <TableRow sx={{ padding: '0' }}>
+      <TableCell sx={{ borderBottom: '4px solid primary.main', padding: 0, whiteSpace: 'nowrap' }}>
         <Checkbox
           checked={completed}
           color='primary'
@@ -95,7 +95,7 @@ const TaskRow = ({ data, displayResponsible }: { data: IEmployeeTask; displayRes
         )}
       </TableCell>
       {modalIsOpen && <InfoModal closeModal={() => setModalIsOpen(false)} employee_task_id={data.id} modalIsOpen={modalIsOpen} />}
-      <TableCell sx={{ border: 0, padding: 0, textAlign: { sm: 'right' } }}>
+      <TableCell sx={{ borderBottom: '1px solid primary.main', padding: 0, textAlign: { sm: 'right' } }}>
         <Link href={`/ansatt/${data.employee.id}`} passHref>
           <ButtonBase className={classNames(classes.avatarRoot, classes.onClick)} focusRipple>
             <Avatar className={classes.avatar} firstName={data.employee.firstName} image={data.employee.imageUrl} lastName={data.employee.lastName} />
@@ -107,7 +107,7 @@ const TaskRow = ({ data, displayResponsible }: { data: IEmployeeTask; displayRes
         </Link>
       </TableCell>
       {displayResponsible && (
-        <TableCell sx={{ border: 0, padding: 0, textAlign: { sm: 'right' }, display: { md: 'table-cell', xs: 'none' } }}>
+        <TableCell sx={{ borderBottom: '1px solid primary.main', padding: 0, textAlign: { sm: 'right' }, display: { md: 'table-cell', xs: 'none' } }}>
           <div className={classes.avatarRoot}>
             <Avatar className={classes.avatar} firstName={data.responsible.firstName} image={data.responsible.imageUrl} lastName={data.responsible.lastName} />
             <Typography
@@ -117,7 +117,7 @@ const TaskRow = ({ data, displayResponsible }: { data: IEmployeeTask; displayRes
           </div>
         </TableCell>
       )}
-      <TableCell sx={{ display: { md: 'table-cell', xs: 'none' }, border: 0, padding: 0 }}>
+      <TableCell sx={{ borderBottom: '1px solid primary.main', display: { md: 'table-cell', xs: 'none' }, padding: 0 }}>
         <Box className={classes.avatarRoot} sx={{ color: hasExpired ? 'error.main' : 'text.primary' }}>
           {daysBeforeDueDate === 0 && 'I dag'}
           {daysBeforeDueDate === 1 && 'I morgen'}

--- a/src/components/views/oppgaver/TaskRow.tsx
+++ b/src/components/views/oppgaver/TaskRow.tsx
@@ -68,7 +68,7 @@ const TaskRow = ({ data, displayResponsible }: { data: IEmployeeTask; displayRes
 
   return (
     <TableRow sx={{ padding: '0' }}>
-      <TableCell sx={{ borderBottom: '4px solid primary.main', padding: 0, whiteSpace: 'nowrap' }}>
+      <TableCell sx={{ border: '0', padding: 0, whiteSpace: 'nowrap' }}>
         <Checkbox
           checked={completed}
           color='primary'
@@ -95,7 +95,7 @@ const TaskRow = ({ data, displayResponsible }: { data: IEmployeeTask; displayRes
         )}
       </TableCell>
       {modalIsOpen && <InfoModal closeModal={() => setModalIsOpen(false)} employee_task_id={data.id} modalIsOpen={modalIsOpen} />}
-      <TableCell sx={{ borderBottom: '1px solid primary.main', padding: 0, textAlign: { sm: 'right' } }}>
+      <TableCell sx={{ border: '0', padding: 0, textAlign: { sm: 'right' } }}>
         <Link href={`/ansatt/${data.employee.id}`} passHref>
           <ButtonBase className={classNames(classes.avatarRoot, classes.onClick)} focusRipple>
             <Avatar className={classes.avatar} firstName={data.employee.firstName} image={data.employee.imageUrl} lastName={data.employee.lastName} />
@@ -107,7 +107,7 @@ const TaskRow = ({ data, displayResponsible }: { data: IEmployeeTask; displayRes
         </Link>
       </TableCell>
       {displayResponsible && (
-        <TableCell sx={{ borderBottom: '1px solid primary.main', padding: 0, textAlign: { sm: 'right' }, display: { md: 'table-cell', xs: 'none' } }}>
+        <TableCell sx={{ border: '0', padding: 0, textAlign: { sm: 'right' }, display: { md: 'table-cell', xs: 'none' } }}>
           <div className={classes.avatarRoot}>
             <Avatar className={classes.avatar} firstName={data.responsible.firstName} image={data.responsible.imageUrl} lastName={data.responsible.lastName} />
             <Typography
@@ -117,7 +117,7 @@ const TaskRow = ({ data, displayResponsible }: { data: IEmployeeTask; displayRes
           </div>
         </TableCell>
       )}
-      <TableCell sx={{ borderBottom: '1px solid primary.main', display: { md: 'table-cell', xs: 'none' }, padding: 0 }}>
+      <TableCell sx={{ border: '0', display: { md: 'table-cell', xs: 'none' }, padding: 0 }}>
         <Box className={classes.avatarRoot} sx={{ color: hasExpired ? 'error.main' : 'text.primary' }}>
           {daysBeforeDueDate === 0 && 'I dag'}
           {daysBeforeDueDate === 1 && 'I morgen'}

--- a/src/pages/ansatt/[id].tsx
+++ b/src/pages/ansatt/[id].tsx
@@ -21,7 +21,6 @@ import Comments from 'components/Comments';
 import DateFormater from 'components/DateFormater';
 import EditDueDateModal from 'components/modals/EditDueDateModal';
 import EditResponsibleModal from 'components/modals/EditResponsibleModal';
-import TextMarkDownWithLink from 'components/TextMarkDownWithLink';
 import useSnackbar from 'context/Snackbar';
 import differenceInCalendarDays from 'date-fns/differenceInCalendarDays';
 import startOfDay from 'date-fns/startOfDay';
@@ -30,6 +29,7 @@ import { GetServerSideProps, InferGetServerSidePropsType } from 'next';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
+import ReactMarkdown from 'react-markdown';
 import safeJsonStringify from 'safe-json-stringify';
 import { prismaDateToFormatedDate, toggleCheckBox } from 'utils/utils';
 import validator from 'validator';
@@ -355,7 +355,7 @@ export const Task = ({ employeeTask }) => {
           <Typography variant='body2'>{`Oppgaveansvarlig: ${employeeTask.responsible.firstName} ${employeeTask.responsible.lastName}`}</Typography>
           <Typography variant='body2'>{`Prosess: ${employeeTask.task.phase.processTemplate.title}`}</Typography>
           <Typography gutterBottom variant='body2'>{`Fase: ${employeeTask.task.phase.title}`}</Typography>
-          <TextMarkDownWithLink text={employeeTask?.task.description} variant={'body2'} />
+          <ReactMarkdown>{employeeTask?.task.description}</ReactMarkdown>
           <Comments employeeTask={employeeTask?.id} />
         </AccordionDetails>
         <AccordionActions

--- a/src/pages/ansatt/[id].tsx
+++ b/src/pages/ansatt/[id].tsx
@@ -12,10 +12,12 @@ import Checkbox from '@mui/material/Checkbox';
 import Container from '@mui/material/Container';
 import IconButton from '@mui/material/IconButton';
 import LinearProgress from '@mui/material/LinearProgress';
+import { Theme } from '@mui/material/styles';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Typography from '@mui/material/Typography';
 import useMediaQuery from '@mui/material/useMediaQuery';
+import { makeStyles } from '@mui/styles';
 import Avatar from 'components/Avatar';
 import Comments from 'components/Comments';
 import DateFormater from 'components/DateFormater';
@@ -33,7 +35,6 @@ import ReactMarkdown from 'react-markdown';
 import safeJsonStringify from 'safe-json-stringify';
 import { prismaDateToFormatedDate, toggleCheckBox } from 'utils/utils';
 import validator from 'validator';
-
 export const getServerSideProps: GetServerSideProps = async ({ query }) => {
   const { id } = query;
   const parsedId = typeof id === 'string' && parseInt(id);
@@ -205,7 +206,16 @@ const Employee = ({ employee, processTemplates }: InferGetServerSidePropsType<ty
   );
 };
 
+const useStyles = makeStyles((theme: Theme) => ({
+  link: {
+    '& a': {
+      color: theme.palette.text.primary,
+    },
+  },
+}));
+
 export const Task = ({ employeeTask }) => {
+  const classes = useStyles();
   const [completed, setCompleted] = useState<boolean>(employeeTask.completed);
   const [loading, isLoading] = useState<boolean>(false);
   const showSnackbar = useSnackbar();
@@ -355,7 +365,7 @@ export const Task = ({ employeeTask }) => {
           <Typography variant='body2'>{`Oppgaveansvarlig: ${employeeTask.responsible.firstName} ${employeeTask.responsible.lastName}`}</Typography>
           <Typography variant='body2'>{`Prosess: ${employeeTask.task.phase.processTemplate.title}`}</Typography>
           <Typography gutterBottom variant='body2'>{`Fase: ${employeeTask.task.phase.title}`}</Typography>
-          <ReactMarkdown>{employeeTask?.task.description}</ReactMarkdown>
+          <ReactMarkdown className={classes.link}>{employeeTask?.task.description}</ReactMarkdown>
           <Comments employeeTask={employeeTask?.id} />
         </AccordionDetails>
         <AccordionActions

--- a/src/pages/ansatt/[id].tsx
+++ b/src/pages/ansatt/[id].tsx
@@ -12,15 +12,14 @@ import Checkbox from '@mui/material/Checkbox';
 import Container from '@mui/material/Container';
 import IconButton from '@mui/material/IconButton';
 import LinearProgress from '@mui/material/LinearProgress';
-import { Theme } from '@mui/material/styles';
 import ToggleButton from '@mui/material/ToggleButton';
 import ToggleButtonGroup from '@mui/material/ToggleButtonGroup';
 import Typography from '@mui/material/Typography';
 import useMediaQuery from '@mui/material/useMediaQuery';
-import { makeStyles } from '@mui/styles';
 import Avatar from 'components/Avatar';
 import Comments from 'components/Comments';
 import DateFormater from 'components/DateFormater';
+import Markdown from 'components/Markdown';
 import EditDueDateModal from 'components/modals/EditDueDateModal';
 import EditResponsibleModal from 'components/modals/EditResponsibleModal';
 import useSnackbar from 'context/Snackbar';
@@ -31,7 +30,6 @@ import { GetServerSideProps, InferGetServerSidePropsType } from 'next';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
-import ReactMarkdown from 'react-markdown';
 import safeJsonStringify from 'safe-json-stringify';
 import { prismaDateToFormatedDate, toggleCheckBox } from 'utils/utils';
 import validator from 'validator';
@@ -206,16 +204,7 @@ const Employee = ({ employee, processTemplates }: InferGetServerSidePropsType<ty
   );
 };
 
-const useStyles = makeStyles((theme: Theme) => ({
-  link: {
-    '& a': {
-      color: theme.palette.text.primary,
-    },
-  },
-}));
-
 export const Task = ({ employeeTask }) => {
-  const classes = useStyles();
   const [completed, setCompleted] = useState<boolean>(employeeTask.completed);
   const [loading, isLoading] = useState<boolean>(false);
   const showSnackbar = useSnackbar();
@@ -365,7 +354,7 @@ export const Task = ({ employeeTask }) => {
           <Typography variant='body2'>{`Oppgaveansvarlig: ${employeeTask.responsible.firstName} ${employeeTask.responsible.lastName}`}</Typography>
           <Typography variant='body2'>{`Prosess: ${employeeTask.task.phase.processTemplate.title}`}</Typography>
           <Typography gutterBottom variant='body2'>{`Fase: ${employeeTask.task.phase.title}`}</Typography>
-          <ReactMarkdown className={classes.link}>{employeeTask?.task.description}</ReactMarkdown>
+          <Markdown text={employeeTask?.task.description} />
           <Comments employeeTask={employeeTask?.id} />
         </AccordionDetails>
         <AccordionActions


### PR DESCRIPTION
Oppdaterte hvordan beskrivelsene ble vist slik at den ikke krasjet når man hadde link, hvilket skjedde før. 

<img width="565" alt="image" src="https://user-images.githubusercontent.com/49594236/155304322-89ac590d-123c-4658-9d6f-8d19e63cb2ba.png">

<img width="869" alt="image" src="https://user-images.githubusercontent.com/49594236/155304776-78979ad5-ac30-4fff-9fe7-401ad5b4c703.png">

