### PR TITLE
Fixed display of completed tasks on employee page

### DIFF
--- a/src/components/modals/EditDueDateModal.tsx
+++ b/src/components/modals/EditDueDateModal.tsx
@@ -44,8 +44,9 @@ const EditDueDateModal = ({ employeeTask, isModalOpen, closeModal }: EditDueDate
       });
 
       router
-        .push({
-          pathname: router.asPath,
+        .push({ pathname: `/ansatt/${employeeTask.employeeId}`, query: { process: employeeTask.task.phase.processTemplate.slug } }, undefined, {
+          shallow: false,
+          scroll: false,
         })
         .finally(() => {
           closeModal();

--- a/src/pages/ansatt/[id].tsx
+++ b/src/pages/ansatt/[id].tsx
@@ -23,7 +23,7 @@ import EditDueDateModal from 'components/modals/EditDueDateModal';
 import EditResponsibleModal from 'components/modals/EditResponsibleModal';
 import useSnackbar from 'context/Snackbar';
 import differenceInCalendarDays from 'date-fns/differenceInCalendarDays';
-import startOfDay from 'date-fns/startOfDay';
+import startOfYear from 'date-fns/startOfYear';
 import { trakClient } from 'lib/prisma';
 import { chain } from 'lodash';
 import { GetServerSideProps, InferGetServerSidePropsType } from 'next';
@@ -31,6 +31,7 @@ import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { Fragment, useEffect, useState } from 'react';
 import safeJsonStringify from 'safe-json-stringify';
+import { Process } from 'utils/types';
 import { prismaDateToFormatedDate, toggleCheckBox } from 'utils/utils';
 import validator from 'validator';
 export const getServerSideProps: GetServerSideProps = async ({ query }) => {
@@ -62,13 +63,27 @@ export const getServerSideProps: GetServerSideProps = async ({ query }) => {
         where: {
           OR: [
             {
+              task: {
+                phase: {
+                  processTemplateId: Process.LOPENDE,
+                },
+              },
               dueDate: {
-                gte: startOfDay(new Date()),
+                gte: startOfYear(new Date()),
               },
             },
             {
-              completed: {
-                equals: false,
+              task: {
+                phase: {
+                  OR: [
+                    {
+                      processTemplateId: Process.ONBOARDING,
+                    },
+                    {
+                      processTemplateId: Process.OFFBOARDING,
+                    },
+                  ],
+                },
               },
             },
           ],
@@ -236,7 +251,7 @@ export const Task = ({ employeeTask, employeeId }) => {
       <Accordion
         TransitionProps={{ unmountOnExit: true }}
         disableGutters
-        sx={{ marginBottom: '16px', borderRadius: '4px', backgroundColor: hasExpired ? 'error.dark' : 'background.paper' }}
+        sx={{ marginBottom: '16px', borderRadius: '4px', backgroundColor: hasExpired && !completed ? 'error.dark' : 'background.paper' }}
       >
         <AccordionSummary
           aria-controls='TASK1_RENAME_ME_PLEASE'

--- a/src/pages/ansatt/[id].tsx
+++ b/src/pages/ansatt/[id].tsx
@@ -251,7 +251,11 @@ export const Task = ({ employeeTask, employeeId }) => {
       <Accordion
         TransitionProps={{ unmountOnExit: true }}
         disableGutters
-        sx={{ marginBottom: '16px', borderRadius: '4px', backgroundColor: hasExpired && !completed ? 'error.dark' : 'background.paper' }}
+        sx={{
+          marginBottom: '16px',
+          borderRadius: '4px',
+          backgroundColor: completed ? 'background.default' : hasExpired && !completed ? 'error.dark' : 'background.paper',
+        }}
       >
         <AccordionSummary
           aria-controls='TASK1_RENAME_ME_PLEASE'


### PR DESCRIPTION
Closes #129 

- Henter ut alle oppgaver i løpende for inneværende år. Det vil si at i Q4 vil man se alle oppgavene
- For onboarding og offboarding vil man alltid hente ut alle, uavhengig av om de er fullført eller når dueDate er
- For oppgaver som har utgått, men er fullført vil de få en grå farge (se bilde), men for de oppgavene som er utgått og ikke fullført vil de fortsatt ha den røde fargen

<img width="926" alt="image" src="https://user-images.githubusercontent.com/49594236/157290067-ef813384-7e30-4272-af57-a915a45db55b.png">

<img width="926" alt="image" src="https://user-images.githubusercontent.com/49594236/157290104-d5d1445b-1cd1-451c-867e-6233a9097974.png">
