### PR TITLE
Feat/markdown editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
 		"react-hook-form": "^7.22.2",
 		"react-linkify": "^1.0.0-alpha",
 		"react-markdown": "6.0.0",
+		"react-markdown-editor-lite": "^1.3.2",
 		"react-mentions": "^4.3.1",
 		"react-scrollable-feed": "^1.3.1",
 		"safe-json-stringify": "^1.2.0",

--- a/src/components/MarkdownEditor.tsx
+++ b/src/components/MarkdownEditor.tsx
@@ -33,14 +33,13 @@ const MarkdownEditor = ({ name, control }: MarkdownEditorProps) => {
       render={({ field: { onChange, value, name } }) => {
         return (
           <MdEditor
-            canView={{ menu: true, md: false, html: true, fullScreen: false, hideMenu: true }}
             className={classes.root}
             name={name}
             onChange={onChange}
+            plugins={['header', 'font-bold', 'font-italic', 'font-underline', 'list-unordered', 'list-ordered', 'link', 'mode-toggle']}
             renderHTML={(text) => <Markdown text={text} />}
             style={{ height: '200px' }}
-            value={value?.text || value}
-            view={{ menu: true, md: true, html: false }}
+            value={typeof value === 'object' ? value?.text : typeof value === 'string' ? value : ''}
           />
         );
       }}

--- a/src/components/MarkdownEditor.tsx
+++ b/src/components/MarkdownEditor.tsx
@@ -1,0 +1,50 @@
+import 'react-markdown-editor-lite/lib/index.css';
+
+import { Theme } from '@mui/material';
+import { makeStyles } from '@mui/styles';
+import Markdown from 'components/Markdown';
+import dynamic from 'next/dynamic';
+import { Controller } from 'react-hook-form';
+
+const MdEditor = dynamic(() => import('react-markdown-editor-lite'), {
+  ssr: false,
+});
+
+const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    '& *': {
+      background: `${theme.palette.background.default} !important`,
+      color: `${theme.palette.text.primary} !important`,
+    },
+  },
+}));
+type MarkdownEditorProps = {
+  name: string;
+  // eslint-disable-next-line
+  control: any;
+};
+
+const MarkdownEditor = ({ name, control }: MarkdownEditorProps) => {
+  const classes = useStyles();
+  return (
+    <Controller
+      control={control}
+      name={name}
+      render={({ field: { onChange, value, name } }) => {
+        return (
+          <MdEditor
+            canView={{ menu: true, md: false, html: true, fullScreen: false, hideMenu: true }}
+            className={classes.root}
+            name={name}
+            onChange={onChange}
+            renderHTML={(text) => <Markdown text={text} />}
+            style={{ height: '200px' }}
+            value={value?.text || value}
+            view={{ menu: true, md: true, html: false }}
+          />
+        );
+      }}
+    />
+  );
+};
+export default MarkdownEditor;

--- a/src/components/views/prosessmal/TaskModal.tsx
+++ b/src/components/views/prosessmal/TaskModal.tsx
@@ -1,4 +1,5 @@
 import HelpIcon from '@mui/icons-material/Help';
+import { Stack } from '@mui/material';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import FormControl from '@mui/material/FormControl';
@@ -18,6 +19,7 @@ import EmployeeSelector from 'components/form/EmployeeSelector';
 import TagSelector from 'components/form/TagSelector';
 import TextField from 'components/form/TextField';
 import ToggleButtonGroup from 'components/form/ToggleButtonGroup';
+import MarkdownEditor from 'components/MarkdownEditor';
 import Modal from 'components/Modal';
 import { useData } from 'context/Data';
 import useProgressbar from 'context/Progressbar';
@@ -42,7 +44,8 @@ export type TaskModalProps = {
 
 export type TaskData = {
   title: string;
-  description?: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  description?: any; // Any because markdownEditor does not return a string but an object of the actualt markdown text and html
   professions?: string[];
   responsible?: IEmployee;
   tags?: ITag[];
@@ -179,6 +182,7 @@ const TaskModal = ({ phase, modalIsOpen, closeModal, task_id = undefined }: Task
           formData.month >= 0 && {
             dueDate: formatISO(new Date().setMonth(formData.month, formData.day)),
           }),
+        description: formData.description.text,
         dueDateDayOffset: dueDateDayOffset,
         responsible: formData.responsibleType === ResponsibleType.OTHER ? formData.responsible : null,
       },
@@ -247,7 +251,7 @@ const TaskModal = ({ phase, modalIsOpen, closeModal, task_id = undefined }: Task
           }}
           sx={{ marginTop: 2 }}
         />
-        <TextField
+        {/* <TextField
           errors={errors}
           inputProps={{ 'aria-label': 'Rediger oppggavebeskrivelse' }}
           label={
@@ -271,7 +275,11 @@ const TaskModal = ({ phase, modalIsOpen, closeModal, task_id = undefined }: Task
           name='description'
           register={register}
           rows={4}
-        />
+        /> */}
+        <Stack spacing={1}>
+          <Typography variant='body1'>Beskrivelse</Typography>
+          <MarkdownEditor control={control} name='description' />
+        </Stack>
         <TextField
           errors={errors}
           inputProps={{ 'aria-label': 'Rediger hurtiglink' }}

--- a/src/components/views/prosessmal/TaskModal.tsx
+++ b/src/components/views/prosessmal/TaskModal.tsx
@@ -251,31 +251,6 @@ const TaskModal = ({ phase, modalIsOpen, closeModal, task_id = undefined }: Task
           }}
           sx={{ marginTop: 2 }}
         />
-        {/* <TextField
-          errors={errors}
-          inputProps={{ 'aria-label': 'Rediger oppggavebeskrivelse' }}
-          label={
-            <>
-              Oppgavebeskrivelse{' '}
-              <Tooltip
-                title={
-                  <>
-                    Dette feltet støtter{' '}
-                    <a href='https://www.markdownguide.org/cheat-sheet/' rel='noreferrer noopener' target='_blank'>
-                      markdown
-                    </a>
-                  </>
-                }
-              >
-                <HelpIcon fontSize='small' />
-              </Tooltip>
-            </>
-          }
-          multiline
-          name='description'
-          register={register}
-          rows={4}
-        /> */}
         <Stack spacing={1}>
           <Typography variant='body1'>Beskrivelse</Typography>
           <MarkdownEditor control={control} name='description' />

--- a/yarn.lock
+++ b/yarn.lock
@@ -78,7 +78,7 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.10.2", "@babel/runtime@^7.13.10", "@babel/runtime@^7.16.3", "@babel/runtime@^7.17.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.13.10", "@babel/runtime@^7.16.3", "@babel/runtime@^7.17.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.7":
   version "7.17.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.17.2.tgz#66f68591605e59da47523c631416b18508779941"
   integrity sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==
@@ -1124,6 +1124,11 @@ classnames@2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
+
+classnames@^2.2.6:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
+  integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
 
 clean-stack@^2.0.0:
   version "2.2.0"
@@ -3604,6 +3609,16 @@ react-linkify@^1.0.0-alpha:
   dependencies:
     linkify-it "^2.0.3"
     tlds "^1.199.0"
+
+react-markdown-editor-lite@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/react-markdown-editor-lite/-/react-markdown-editor-lite-1.3.2.tgz#734646ab619ac707fe9c366153cc0d323a376f59"
+  integrity sha512-pjtu+tpTjc2u4hauFozzbX7EQEnKCCfDCEAY4vnc0AXCPqdFwaoe7A/Fb3J8qwUIS1Ox5XVjeRWKt11FgrMdZA==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    classnames "^2.2.6"
+    eventemitter3 "^4.0.0"
+    uuid "^8.3.2"
 
 react-markdown@6.0.0:
   version "6.0.0"


### PR DESCRIPTION
Closes #108 

For øyeblikket kun i prosessmal da det var nærmest umulig å klare å få implementert både mentions og markdown editor i kommentarer :( 

Har kun med de toolbar-mulighetene som vår markdown renderer kan rendre, og dermed også gjort den så enkel som mulig. 

<img width="589" alt="image" src="https://user-images.githubusercontent.com/49594236/158265936-5982b3fe-c0fd-4edc-be27-9e08257edf8c.png">

<img width="589" alt="image" src="https://user-images.githubusercontent.com/49594236/158265954-584492ce-a599-4809-9968-3c9160e5cbf3.png">

<img width="589" alt="image" src="https://user-images.githubusercontent.com/49594236/158265962-c2c1febc-a6f7-4622-a458-ff424013837e.png">
